### PR TITLE
fix: openpyxl>=3.1.x WorkSheetParser attribute error

### DIFF
--- a/src/patches/patch_openpyxl.py
+++ b/src/patches/patch_openpyxl.py
@@ -14,7 +14,7 @@ def bind_cells(self):
             c._value = cell['value']
             c.data_type = cell['data_type']
             self.ws._cells[(cell['row'], cell['column'])] = c
-    self.ws.formula_attributes = self.parser.array_formulae
+    self.ws.formula_attributes = self.parser.parse_formula
     if self.ws._cells:
         self.ws._current_row = self.ws.max_row # use cells not row dimensions
 WorksheetReader.bind_cells = bind_cells


### PR DESCRIPTION
Hi, first of all, thank you so much for this great project. It helped me tremendously with generating over 80 name tags and desk nameplates — I truly appreciate your efforts!

### Problem
While using the project, I encountered an error that seems to stem from a compatibility issue with the openpyxl library version (>=3.1.x). Below are the error messages I received:

```
AttributeError: 'WorkSheetParser' object has no attribute 'array_formulae'. Did you mean: 'parse_formula'?
```
### Suggestion
![스크린샷 2025-04-07 162040](https://github.com/user-attachments/assets/562e4a73-53aa-4061-94d1-23401dadc158)

According to [StackOverflow](https://stackoverflow.com/a/76418159) and the official [openpyxl documentation](https://openpyxl.readthedocs.io/en/latest/changes.html?highlight=formula_attributes#deprecations), the properties formula_attributes were changed in newer versions of openpyxl. As a result, I suggest modifying the following line in src/patches/patch_openpyxl.py, L17:

```
# Current code:
self.ws.formula_attributes = self.parser.array_formulae

# Suggested fix:
self.ws.formula_attributes = self.parser.parse_formula
```

### Experiment environment:
* OS: Windows 11
* Python: 3.10.11
* openpyxl: 3.1.5
* python-pptx: 1.0.2

I would be happy to open a PR with this change if needed.
Thanks again for maintaining this helpful project!

God bless you : )